### PR TITLE
stylelint-config-css-modulesを追加する

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -12,6 +12,7 @@
       "custom-properties",
       "declarations"
     ],
-    "order/properties-alphabetical-order": true
+    "order/properties-alphabetical-order": true,
+    "selector-class-pattern": null
   }
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,7 +1,8 @@
 {
   "extends": [
     "stylelint-config-standard",
-    "stylelint-config-sass-guidelines"
+    "stylelint-config-sass-guidelines",
+    "stylelint-config-css-modules"
   ],
   "plugins": [
     "stylelint-order"

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "husky": "^6.0.0",
         "lint-staged": "^11.0.0",
         "stylelint": "^13.13.1",
+        "stylelint-config-css-modules": "^2.2.0",
         "stylelint-config-sass-guidelines": "^8.0.0",
         "stylelint-config-standard": "^22.0.0",
         "stylelint-order": "^4.1.0"
@@ -21288,6 +21289,15 @@
         "url": "https://opencollective.com/stylelint"
       }
     },
+    "node_modules/stylelint-config-css-modules": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-css-modules/-/stylelint-config-css-modules-2.2.0.tgz",
+      "integrity": "sha512-+zjcDbot+zbuxy1UA31k4G2lUG+nHUwnLyii3uT2F09B8kT2YrT9LZYNfMtAWlDidrxr7sFd5HX9EqPHGU3WKA==",
+      "dev": true,
+      "peerDependencies": {
+        "stylelint": "11.x - 13.x"
+      }
+    },
     "node_modules/stylelint-config-recommended": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-5.0.0.tgz",
@@ -42224,6 +42234,13 @@
           "dev": true
         }
       }
+    },
+    "stylelint-config-css-modules": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-css-modules/-/stylelint-config-css-modules-2.2.0.tgz",
+      "integrity": "sha512-+zjcDbot+zbuxy1UA31k4G2lUG+nHUwnLyii3uT2F09B8kT2YrT9LZYNfMtAWlDidrxr7sFd5HX9EqPHGU3WKA==",
+      "dev": true,
+      "requires": {}
     },
     "stylelint-config-recommended": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "husky": "^6.0.0",
     "lint-staged": "^11.0.0",
     "stylelint": "^13.13.1",
+    "stylelint-config-css-modules": "^2.2.0",
     "stylelint-config-sass-guidelines": "^8.0.0",
     "stylelint-config-standard": "^22.0.0",
     "stylelint-order": "^4.1.0"


### PR DESCRIPTION
stylelint-config-css-modulesを追加しても、`stylelint-config-sass-guidelines`で`Selector should be written in lowercase with hyphens (selector-class-pattern)`のエラーが発生するので`"selector-class-pattern": null`を追加しました。